### PR TITLE
Update README.adoc - Single Segment Namespace note

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -104,6 +104,8 @@ Fortunately, we have an easy solution for you:
 . include https://clojars.org/com.github.clj-easy/graal-build-time[clj-easy/graal-build-time] on your `native-image` classpath
 . specify `--features=clj_easy.graal_build_time.InitClojureClasses` on your `native-image` command line
 
+_Note: https://github.com/clj-easy/graal-build-time?tab=readme-ov-file#single-segment-namespaces[graal-build-time]  doesn't work with single segment namespaces. A single segment namespace is one without any `.` characters in it, for example: `(ns digest)`._
+
 See https://github.com/clj-easy/graal-build-time[graal-build-time docs] for details.
 
 === Runtime Evaluation


### PR DESCRIPTION
Add note about single segment namespaces not working with graal-build-time.

Someone ran into this issue recently, https://clojurians.slack.com/archives/CAJN79WNT/p1715181467187289. I thought it would be helpful to also include a redundant note in the readme.